### PR TITLE
Fix bug: replace api url BitcoinMainnet to QtumMainnet

### DIFF
--- a/electrum/submarine_swaps.py
+++ b/electrum/submarine_swaps.py
@@ -142,9 +142,9 @@ class SwapManager(Logger):
             if swap.is_reverse and swap.prepay_hash is not None:
                 self.prepayments[swap.prepay_hash] = bytes.fromhex(k)
         # api url
-        if constants.net == constants.BitcoinMainnet:
+        if constants.net == constants.QtumMainnet:
             self.api_url = API_URL_MAINNET
-        elif constants.net == constants.BitcoinTestnet:
+        elif constants.net == constants.QtumTestnet:
             self.api_url = API_URL_TESTNET
         else:
             self.api_url = API_URL_REGTEST


### PR DESCRIPTION
This causes a bug in the "create" command that creates a wallet among CLI commands.